### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ulvy156/back-end-nest/security/code-scanning/1](https://github.com/Ulvy156/back-end-nest/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the operations performed in this workflow (e.g., checking out the repository and running tests). This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
