### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ulvy156/back-end-nest/security/code-scanning/2](https://github.com/Ulvy156/back-end-nest/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow (e.g., checking out code, installing dependencies, running tests), the workflow only needs `contents: read` permission. This ensures that the workflow cannot perform any unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
