### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Ulvy156/back-end-nest/security/code-scanning/3](https://github.com/Ulvy156/back-end-nest/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `build-and-test` job, specifying the minimal required permissions. Since the job only performs read operations, we will set `contents: read`. This ensures that the job has the least privilege necessary to complete its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
